### PR TITLE
Remove DCTLENV_PGP env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ No SHA256 hashes file available. Skipping SHA256 hash validation
 Installation of driftctl v0.2.3 successful. To make this your default version, run 'dctlenv use 0.2.3'
 ```
 
-For signed version of driftctl (starting v0.4.0) you can now install and verify digital signature with dctlenv.
+For signed version of driftctl (starting v0.10.0) you can now install and verify digital signature with dctlenv.
 
-You will need first to import the public key of CloudSkiff and then use the environment variable `DCTLENV_PGP`.
+You just need to import the public key of CloudSkiff and have the gpg binary already installed.
 
 ```console
 # Import key
@@ -85,15 +85,15 @@ gpg: Total number processed: 1
 gpg:               imported: 1
 
 # Install and verify signature
-$ DCTLENV_PGP=1 dctlenv install 0.4.0
-Installing driftctl v0.4.0
-Downloading release tarball from https://github.com/snyk/driftctl/releases/download/v0.4.0/driftctl_darwin_amd64
+$ dctlenv install 0.10.0
+Installing driftctl v0.10.0
+Downloading release tarball from https://github.com/snyk/driftctl/releases/download/v0.10.0/driftctl_darwin_amd64
 ######################################################################################################################## 100.0%
-Downloading SHA256 hashes file from https://github.com/snyk/driftctl/releases/download/v0.4.0/driftctl_SHA256SUMS
+Downloading SHA256 hashes file from https://github.com/snyk/driftctl/releases/download/v0.10.0/driftctl_SHA256SUMS
 SHA256 hash matched!
-Downloading SHA256 hashes signature file from https://github.com/snyk/driftctl/releases/download/v0.4.0/driftctl_SHA256SUMS.gpg
+Downloading SHA256 hashes signature file from https://github.com/snyk/driftctl/releases/download/v0.10.0/driftctl_SHA256SUMS.gpg
 PGP signature matched!
-Installation of driftctl v0.4.0 successful. To make this your default version, run 'dctlenv use 0.4.0'
+Installation of driftctl v0.10.0 successful. To make this your default version, run 'dctlenv use 0.10.0'
 ```
 
 ### `dctlenv use [<version>]`
@@ -267,7 +267,6 @@ You can configure how `dctlenv` operates with the following settings:
 | `DCTLENV_ROOT`  |         | Defines the directory under which dctlenv resides<br> Current value shown by `dctlenv root` |
 | `DCTLENV_ARCH`  | `amd64` | Architecture other than the default amd64 can be specified                                  |
 | `DCTLENV_DEBUG` | `0`     | Outputs debug information                                                                   |
-| `DCTLENV_PGP`   | `0`     | Verify digital signatures                                                                   |
 | `DCTLENV_CURL`  | `0`     | Curl download progress bar, 0 will run a -# curl and 1 will run a -s curl                   |
 
 ## Contributors ✨

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -15,3 +15,9 @@ curlw() {
   curl $TLS_OPT "$@"
 }
 export -f curlw
+
+# Check if one version is lower or equal to another version
+version_le() {
+  [ "$1" = "`echo -e "$1\n$2" | sort -V | head -n 1`" ]
+}
+export -f version_le

--- a/libexec/dctlenv-install
+++ b/libexec/dctlenv-install
@@ -53,6 +53,14 @@ case "${DCTLENV_CURL:-0}" in
     ;;
 esac
 
+# By default we enable the PGP verification unless the
+# version is below or equal to 0.9.1
+pgp=1
+if version_le $version "0.9.1"; then
+  pgp=0
+fi
+
+driftctl_key="0xACC776A79C824EBD"
 driftctl_url="https://github.com/snyk/driftctl/releases/download"
 
 echo "Installing driftctl v$version"
@@ -72,31 +80,40 @@ if [[ -f "$dst_path/driftctl_SHA256SUMS" ]]; then
   else
     echo 'No sha256sum tool available. Skipping SHA256 hash validation'
   fi
-  if [ "${DCTLENV_PGP:-0}" -eq 0 ]; then
+  if [ $pgp -eq 0 ]; then
     $(rm "$dst_path/driftctl_SHA256SUMS")
   fi
 else
   echo 'No SHA256 hashes file available. Skipping SHA256 hash validation'
 fi
 
-if [ "${DCTLENV_PGP:-0}" -gt 0 ]; then
-  echo "Downloading SHA256 hashes signature file from $driftctl_url/v$version/driftctl_SHA256SUMS.gpg"
-  $(curlw -s -f -L -o "$dst_path/driftctl_SHA256SUMS.gpg" "$driftctl_url/v$version/driftctl_SHA256SUMS.gpg") || log_debug 'SHA256 hashes signature download failed'
+bin_is_verified=0
+if [ $pgp -eq 1 ]; then
+  gpg_bin="$(command -v gpg 2>/dev/null)"
+  if [[ -n "$gpg_bin" ]]; then
+    # Check if we have the key to verify the signature
+    ("$gpg_bin" --list-keys $driftctl_key) &>/dev/null \
+      && has_key=1 \
+      || has_key=0
+    if [ $has_key -eq 1 ]; then
+      echo "Downloading SHA256 hashes signature file from $driftctl_url/v$version/driftctl_SHA256SUMS.gpg"
+      $(curlw -s -f -L -o "$dst_path/driftctl_SHA256SUMS.gpg" "$driftctl_url/v$version/driftctl_SHA256SUMS.gpg") || log_debug 'SHA256 hashes signature download failed'
 
-  if [[ -f "$dst_path/driftctl_SHA256SUMS.gpg" ]]; then
-    gpg_bin="$(command -v gpg 2>/dev/null)"
-    if [[ -n "$gpg_bin" ]]; then
-      ("$gpg_bin" --verify "$dst_path/driftctl_SHA256SUMS.gpg" "$dst_path/driftctl_SHA256SUMS") &>/dev/null \
-      && echo "PGP signature matched!" \
-      || log_error 'PGP signature rejected!'
-    else
-      echo 'No gpg tool available. Skipping signature validation'
+      if [[ -f "$dst_path/driftctl_SHA256SUMS.gpg" ]]; then
+        ("$gpg_bin" --verify "$dst_path/driftctl_SHA256SUMS.gpg" "$dst_path/driftctl_SHA256SUMS") &>/dev/null \
+          && echo "PGP signature matched!" && bin_is_verified=1 \
+          || log_error 'PGP signature rejected!'
+        $(rm "$dst_path/driftctl_SHA256SUMS.gpg")
+      else
+        echo 'No SHA256 hashes signature file available. Skipping signature validation'
+      fi
     fi
-    $(rm "$dst_path/driftctl_SHA256SUMS.gpg")
-  else
-    echo 'No SHA256 hashes signature file available. Skipping signature validation'
   fi
   $(rm "$dst_path/driftctl_SHA256SUMS")
+fi
+
+if [ $bin_is_verified -eq 0 ]; then
+  echo 'Unable to verify the authenticity of the binary'
 fi
 
 $(mv "$dst_path/driftctl_$os" "$dst_path/driftctl")


### PR DESCRIPTION
@eliecharra I tried to follow your issue as much as possible.

As for the warning in yellow and the success in green. I will probably need to rewrite the logger to take it into account internally. For now it's simply `echo` if it succeed or was unable to verify the signature.

Do you know any good contents or best practices about logging in a terminal CLI?