### PR TITLE
Improve error message for version-name

### DIFF
--- a/libexec/dctlenv-exec
+++ b/libexec/dctlenv-exec
@@ -5,7 +5,7 @@ log_debug 'Getting version from dctlenv-version-name'
 
 DCTLENV_VERSION="$(dctlenv-version-name 2>/dev/null)" \
   && log 'debug' "DCTLENV_VERSION is $DCTLENV_VERSION" \
-  || log_error 'Failed to get version from dctlenv-version-name'
+  || log_error 'Failed to get version from dctlenv-version-name. Did you run dctlenv use <version> ?'
 
 if [ ! -d "$DCTLENV_ROOT/versions/$DCTLENV_VERSION" ]; then
   log_error "Version '$DCTLENV_VERSION' was requested, but not installed"

--- a/test/dctlenv-exec.bats
+++ b/test/dctlenv-exec.bats
@@ -12,7 +12,7 @@ setup() {
   run dctlenv exec
 
   assert_failure
-  assert_output 'Failed to get version from dctlenv-version-name'
+  assert_output 'Failed to get version from dctlenv-version-name. Did you run dctlenv use <version> ?'
 }
 
 @test "dctlenv exec: prints error messages if it fails to execute" {


### PR DESCRIPTION
On a fresh install of dctlenv, even when you install a version, it is not used by default so you have to run dctlenv use first, then run driftctl. So when you forget about this step, the error message shows "Failed to get version from dctlenv-version-name" which can be confusing as the user has no clue about what is dctlenv-version-name.