### PR TITLE
chore: change GPG key based on driftctl version

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ You just need to import the public key of CloudSkiff and have the gpg binary alr
 
 ```console
 # Import key
-$ gpg --keyserver hkps://keys.openpgp.org --recv-keys 0xACC776A79C824EBD
+$ gpg --keyserver hkps://keys.openpgp.org --recv-keys 277666005A7F01D484F6376DACC776A79C824EBD
 gpg: key ACC776A79C824EBD: public key "Cloudskiff <security@cloudskiff.com>" imported
 gpg: Total number processed: 1
 gpg:               imported: 1
@@ -94,6 +94,16 @@ SHA256 hash matched!
 Downloading SHA256 hashes signature file from https://github.com/snyk/driftctl/releases/download/v0.10.0/driftctl_SHA256SUMS.gpg
 PGP signature matched!
 Installation of driftctl v0.10.0 successful. To make this your default version, run 'dctlenv use 0.10.0'
+```
+
+As of 05/01/23, a CircleCI breach has been discovered. You can read more about it [here](https://circleci.com/blog/january-4-2023-security-alert/). The driftctl team has been rotated its signing key and you will need to import the new one to verify the signature of all version starting from v0.38.2.
+
+```console
+# Import key
+$ gpg --keyserver hkps://keys.openpgp.org --recv-keys 65DDA08AA1605FC8211FC928FFB5FCAFD223D274
+gpg: key ACC776A79C824EBD: public key "Cloudskiff <security@cloudskiff.com>" imported
+gpg: Total number processed: 1
+gpg:               imported: 1
 ```
 
 ### `dctlenv use [<version>]`

--- a/libexec/dctlenv-install
+++ b/libexec/dctlenv-install
@@ -60,7 +60,13 @@ if version_le $version "0.9.1"; then
   pgp=0
 fi
 
-driftctl_key="0xACC776A79C824EBD"
+# Since CircleCI breach on 05/01/23, driftctl changed its signing key
+# which means the PGP signature will be different for versions below 0.38.1
+driftctl_key="65DDA08AA1605FC8211FC928FFB5FCAFD223D274"
+if version_le $version "0.38.1"; then
+  driftctl_key="277666005A7F01D484F6376DACC776A79C824EBD"
+fi
+
 driftctl_url="https://github.com/snyk/driftctl/releases/download"
 
 echo "Installing driftctl v$version"
@@ -107,6 +113,8 @@ if [ $pgp -eq 1 ]; then
       else
         echo 'No SHA256 hashes signature file available. Skipping signature validation'
       fi
+    else
+      echo "To verify the authenticity of the binary, you need to import the key ${driftctl_key}"
     fi
   fi
   $(rm "$dst_path/driftctl_SHA256SUMS")

--- a/test/dctlenv-install.bats
+++ b/test/dctlenv-install.bats
@@ -16,7 +16,8 @@ setup() {
 0.2.3
 0.3.0
 0.3.1
-0.10.0"
+0.10.0
+0.38.2"
   }
   export -f dctlenv-list-remote;
 
@@ -187,9 +188,9 @@ OUT
 @test "dctlenv install [<version>]: prints a success message if it can install the latest version" {
   uname() { echo "Linux"; }; export -f uname;
   curlw() {
-    mkdir -p "$DCTLENV_TMPDIR/versions/0.10.0"
-    touch "$DCTLENV_TMPDIR/versions/0.10.0/driftctl_linux_amd64"
-    (cd "$DCTLENV_TMPDIR/versions/0.10.0"; sha256sum * > "$DCTLENV_TMPDIR/versions/0.10.0/driftctl_SHA256SUMS")
+    mkdir -p "$DCTLENV_TMPDIR/versions/0.38.2"
+    touch "$DCTLENV_TMPDIR/versions/0.38.2/driftctl_linux_amd64"
+    (cd "$DCTLENV_TMPDIR/versions/0.38.2"; sha256sum * > "$DCTLENV_TMPDIR/versions/0.38.2/driftctl_SHA256SUMS")
     exit 0
   }; export -f curlw;
   gpg() { exit 0; }; export -f gpg;
@@ -198,16 +199,16 @@ OUT
 
   assert_success
   assert_output <<OUT
-Installing driftctl v0.10.0
-Downloading release tarball from https://github.com/snyk/driftctl/releases/download/v0.10.0/driftctl_linux_amd64
-Downloading SHA256 hashes file from https://github.com/snyk/driftctl/releases/download/v0.10.0/driftctl_SHA256SUMS
+Installing driftctl v0.38.2
+Downloading release tarball from https://github.com/snyk/driftctl/releases/download/v0.38.2/driftctl_linux_amd64
+Downloading SHA256 hashes file from https://github.com/snyk/driftctl/releases/download/v0.38.2/driftctl_SHA256SUMS
 SHA256 hash matched!
-Downloading SHA256 hashes signature file from https://github.com/snyk/driftctl/releases/download/v0.10.0/driftctl_SHA256SUMS.gpg
+Downloading SHA256 hashes signature file from https://github.com/snyk/driftctl/releases/download/v0.38.2/driftctl_SHA256SUMS.gpg
 No SHA256 hashes signature file available. Skipping signature validation
 Unable to verify the authenticity of the binary
-Installation of driftctl v0.10.0 successful. To make this your default version, run 'dctlenv use 0.10.0'
+Installation of driftctl v0.38.2 successful. To make this your default version, run 'dctlenv use 0.38.2'
 OUT
-  refute [ -e "$DCTLENV_TMPDIR/versions/0.10.0/driftctl_SHA256SUMS" ]
+  refute [ -e "$DCTLENV_TMPDIR/versions/0.38.2/driftctl_SHA256SUMS" ]
 }
 
 @test "dctlenv install [<version>]: prints a missing hashes signature file" {
@@ -290,6 +291,38 @@ SHA256 hash matched!
 Downloading SHA256 hashes signature file from https://github.com/snyk/driftctl/releases/download/v0.10.0/driftctl_SHA256SUMS.gpg
 PGP signature matched!
 Installation of driftctl v0.10.0 successful. To make this your default version, run 'dctlenv use 0.10.0'
+OUT
+  refute [ -e "$DCTLENV_TMPDIR/versions/0.10.0/driftctl_SHA256SUMS" ]
+  refute [ -e "$DCTLENV_TMPDIR/versions/0.10.0/driftctl_SHA256SUMS.gpg" ]
+}
+
+@test "dctlenv install [<version>]: prints a message if you did not import the right key based on the version of driftctl" {
+  uname() { echo "Linux"; }; export -f uname;
+  curlw() {
+    mkdir -p "$DCTLENV_TMPDIR/versions/0.38.2"
+    touch "$DCTLENV_TMPDIR/versions/0.38.2/driftctl_linux_amd64"
+    (cd "$DCTLENV_TMPDIR/versions/0.38.2"; sha256sum * > "$DCTLENV_TMPDIR/versions/0.38.2/driftctl_SHA256SUMS")
+    touch "$DCTLENV_TMPDIR/versions/0.38.2/driftctl_SHA256SUMS.gpg"
+    exit 0
+  }; export -f curlw;
+  gpg() {
+    if [ $1 == "--list-keys" ]; then
+      exit 1
+    fi
+    exit 0
+  }; export -f gpg;
+
+  run dctlenv install 0.38.2
+
+  assert_success
+  assert_output <<OUT
+Installing driftctl v0.38.2
+Downloading release tarball from https://github.com/snyk/driftctl/releases/download/v0.38.2/driftctl_linux_amd64
+Downloading SHA256 hashes file from https://github.com/snyk/driftctl/releases/download/v0.38.2/driftctl_SHA256SUMS
+SHA256 hash matched!
+To verify the authenticity of the binary, you need to import the key 65DDA08AA1605FC8211FC928FFB5FCAFD223D274
+Unable to verify the authenticity of the binary
+Installation of driftctl v0.38.2 successful. To make this your default version, run 'dctlenv use 0.38.2'
 OUT
   refute [ -e "$DCTLENV_TMPDIR/versions/0.10.0/driftctl_SHA256SUMS" ]
   refute [ -e "$DCTLENV_TMPDIR/versions/0.10.0/driftctl_SHA256SUMS.gpg" ]


### PR DESCRIPTION
Since the CircleCI breach on 05/01/23, driftctl team has changed the signing key.

dctlenv needs to take that into account when someone tries to install a version after v0.38.1.